### PR TITLE
Fix for "unary operator expected" issue

### DIFF
--- a/pihotspot.sh
+++ b/pihotspot.sh
@@ -414,7 +414,7 @@ else
 	exit 1;
 fi
 
-if [ $HOTSPOT_IP != $WAN_INTERFACE_IP ]; then
+if [[ $HOTSPOT_IP != $WAN_INTERFACE_IP ]]; then
 	display_message "Checking that HOTSPOT_IP is not the same than the WAN_INTERFACE : OK"
 else
 	display_message ""


### PR DESCRIPTION
Fix for "./pihotspot.sh: line 417: [: 192.168.x.x : unary operator expected" issue when starting script