### PR TITLE
WAN_INTERFACE instead of hard-coded eth0 / Fix error cloning webui

### DIFF
--- a/pihotspot.sh
+++ b/pihotspot.sh
@@ -113,8 +113,8 @@ PKG_UPGRADE="${PKG_MANAGER} --yes upgrade"
 PKG_DIST_UPGRADE="apt dist-upgrade -y --allow-remove-essential --allow-change-held-packages"
 PKG_COUNT="${PKG_MANAGER} -s -o Debug::NoLocking=true upgrade | grep -c ^Inst || true"
 
-WAN_INTERFACE_IP=`ifconfig eth0 | grep "inet " | cut -d ' ' -f 10`
-WAN_INTERFACE_IP_MASK=`ifconfig eth0 | grep "inet " | cut -d ' ' -f 13`
+WAN_INTERFACE_IP=`ifconfig $WAN_INTERFACE | grep "inet " | cut -d ' ' -f 10`
+WAN_INTERFACE_IP_MASK=`ifconfig $WAN_INTERFACE | grep "inet " | cut -d ' ' -f 13`
 
 IFS=. read -r i1 i2 i3 i4 <<< "$WAN_INTERFACE_IP"
 IFS=. read -r m1 m2 m3 m4 <<< "$WAN_INTERFACE_IP_MASK"

--- a/pihotspot.sh
+++ b/pihotspot.sh
@@ -285,7 +285,7 @@ download_all_sources() {
 
   execute_command "cd /usr/src && git clone $COOVACHILLI_ARCHIVE coova-chilli" true "Cloning CoovaChilli project"
 
-  execute_command "cd /usr/src && git clone $KUPIKI_WEBUI_ARCHIVE webui" true "Cloning Kupiki Web UI project"
+  execute_command "cd /usr/src && rm -rf webui && git clone $KUPIKI_WEBUI_ARCHIVE webui" true "Cloning Kupiki Web UI project"
 
   if [[ "$HASERL_INSTALL" = "Y" ]]; then
 


### PR DESCRIPTION
I think this error is unseen by many because the default WAN_INTERFACE is **eth0**.
But in my case, where it is set to  **enxb827eb3b3cad** , I start receiving this error:

> HOTSPOT_IP is the same than the WAN_INTERFACE. They must be different.

After checking, I realized that **eth0** was hard-coded in _pihotspot.sh_  instead of using the **WAN_INTERFACE** variable.



